### PR TITLE
Update the network mask

### DIFF
--- a/00-aks-host/Readme.md
+++ b/00-aks-host/Readme.md
@@ -1,3 +1,5 @@
-# Deploy the Azure Kubernetes Service host
+# Deploy the Azure Kubernetes Services (AKS) management cluster
 
-[![AKS Host deployment](https://img.youtube.com/vi/5fIOFFtfH2Y/0.jpg)](https://youtu.be/5fIOFFtfH2Y)
+The Azure Kubernetes Services (AKS) management cluster, also known as the AKS Host, management cluster, or KVA, is a crucial component for managing hybrid AKS clusters. Throughout this module, you will learn how to deploy this cluster by fulfilling all necessary prerequisites and running the `Install-AksHci` command. Click on the image bellow for a video recording of the process:
+
+[![AKS Host deployment](https://img.youtube.com/vi/GGN7ICJ50dU/maxresdefault.jpg)](https://youtu.be/GGN7ICJ50dU)

--- a/00-aks-host/script.ps1
+++ b/00-aks-host/script.ps1
@@ -1,3 +1,6 @@
+# Variables used in this script, defined in ../env.ps1
+# $subscriptionId, $tenenantId, $resourceGroup
+
 # Sign in to Azure
 Connect-AzAccount -Tenant $tenenantId
 Set-AzContext -Subscription $subscriptionId
@@ -16,6 +19,8 @@ Get-AzResourceProvider -ProviderNamespace Microsoft.KubernetesConfiguration
 
 # Initialize node
 Initialize-AksHciNode
+
+# Create folders in V: drive
 New-Item -Path "V:\" -Name "AKS-HCI" -ItemType "directory" -Force
 New-Item -Path "V:\AKS-HCI\" -Name "Images" -ItemType "directory" -Force
 New-Item -Path "V:\AKS-HCI\" -Name "WorkingDir" -ItemType "directory" -Force
@@ -23,13 +28,14 @@ New-Item -Path "V:\AKS-HCI\" -Name "Config" -ItemType "directory" -Force
 
 # Create network
 $vnet = New-AksHciNetworkSetting -name "mgmtvnet" -vSwitchName "InternalNAT" -gateway "192.168.0.1" -dnsservers "192.168.0.1" `
-    -ipaddressprefix "192.168.0.0/24" -k8snodeippoolstart "192.168.0.3" -k8snodeippoolend "192.168.0.149" `
+    -ipaddressprefix "192.168.0.0/16" -k8snodeippoolstart "192.168.0.3" -k8snodeippoolend "192.168.0.149" `
     -vipPoolStart "192.168.0.150" -vipPoolEnd "192.168.0.250"
 
-# Install aks host (use specific version if you're planning to deploy Arc Resource Bridge)
+# Configure aks host (use specific version if you're planning to deploy Arc Resource Bridge)
 Set-AksHciConfig -vnet $vnet -imageDir "V:\AKS-HCI\Images" -workingDir "V:\AKS-HCI\WorkingDir" `
    -cloudConfigLocation "V:\AKS-HCI\Config" -Verbose -version "1.0.13.10907"
 
 Set-AksHciRegistration -SubscriptionId $subscriptionId -ResourceGroupName $resourceGroup
 
+# Install AKS host
 Install-AksHci

--- a/00-aks-host/script.ps1
+++ b/00-aks-host/script.ps1
@@ -17,7 +17,7 @@ if ((Get-AzResourceProvider -ProviderNamespace Microsoft.KubernetesConfiguration
 Get-AzResourceProvider -ProviderNamespace Microsoft.Kubernetes
 Get-AzResourceProvider -ProviderNamespace Microsoft.KubernetesConfiguration
 
-# Initialize node
+# Initialize node. Run checks on every physical node to see if all requirements are satisfied to install AKS hybrid.
 Initialize-AksHciNode
 
 # Create folders in V: drive

--- a/01-new-workload-cluster/script.ps1
+++ b/01-new-workload-cluster/script.ps1
@@ -1,28 +1,36 @@
-$clusterName="wld01-cluster"
-$subscriptionId = "f89ca1d5-8a0f-413e-aa15-8d22bf52c8f6"
+# Variables used in this script, defined in ../env.ps1
+# $workloadClusterName, $subscriptionId, $tenenantId
 
-# Create cluster with network
-$vnet = New-AksHciClusterNetwork -name $clusterName -vswitchName "InternalNAT" -gateway "192.168.0.1" -dnsServers "192.168.0.1" -ipAddressPrefix "192.168.0.0/16" -vipPoolStart "192.168.1.150" -vipPoolEnd "192.168.1.250" -k8sNodeIpPoolStart "192.168.1.3" -k8sNodeIpPoolEnd "192.168.1.149"
-New-AksHciCluster -name $clusterName -nodePoolName linuxnodepool -controlPlaneNodeCount 1 -nodeCount 1 -osType linux -vnet $vnet
+# Create cluster with new network settings, so that the cluster can use different vipPoolStart and vipPoolEnd than the management cluster
+$vnet = New-AksHciClusterNetwork -name $workloadClusterName -vswitchName "InternalNAT" -gateway "192.168.0.1" -dnsServers "192.168.0.1" -ipAddressPrefix "192.168.0.0/16" -vipPoolStart "192.168.1.150" -vipPoolEnd "192.168.1.250" -k8sNodeIpPoolStart "192.168.1.3" -k8sNodeIpPoolEnd "192.168.1.149"
+New-AksHciCluster -name $workloadClusterName -nodePoolName linuxnodepool -controlPlaneNodeCount 1 -nodeCount 1 -osType linux -vnet $vnet
 
-# Create cluster in mgmt network
-New-AksHciCluster -name $clusterName -nodePoolName linuxnodepool -controlPlaneNodeCount 1 -nodeCount 1 -osType linux
+# We could also create a cluster with the default network settings by ommiting the -vnet parameter
+# New-AksHciCluster -name $workloadClusterName -nodePoolName linuxnodepool -controlPlaneNodeCount 1 -nodeCount 1 -osType linux
 
 # View cluster resources
 Get-AksHciCluster
-Get-AksHciNodePool -clusterName $clusterName
+Get-AksHciNodePool -clusterName $workloadClusterName
+
+# You can access the cluster through kubectl, getting the kubeconfig file with the following command
+Get-AksHciCredential -name $workloadClusterName
+
+### Manage the cluster
 
 # Add nodePool
-New-AksHciNodePool -clusterName $clusterName -name windowsnodepool -count 1 -osType windows
+New-AksHciNodePool -clusterName $workloadClusterName -name windowsnodepool -count 1 -osType windows
 
 # Scale nodePool
-Set-AksHciNodePool -clusterName $clusterName -name linuxnodepool -count 2
-# Scale control controlPlane
-Set-AksHciCluster –Name $clusterName -controlPlaneNodeCount 3
+Set-AksHciNodePool -clusterName $workloadClusterName -name linuxnodepool -count 2
+# Scale controlPlane
+Set-AksHciCluster –Name $workloadClusterName -controlPlaneNodeCount 3
+
+
+### Integrate the workload cluster with Azure Arc
 
 # Sign in to Azure
-Connect-AzAccount
+Connect-AzAccount -Tenant $tenenantId
 Set-AzContext -Subscription $subscriptionId
 
-# Integrate your target cluster with Azure Arc
-Enable-AksHciArcConnection -name $clusterName
+# Make the connection of the cluster with Azure Arc
+Enable-AksHciArcConnection -name $workloadClusterName

--- a/env.ps1
+++ b/env.ps1
@@ -2,3 +2,6 @@
 $tenenantId = "28fb5b77-7c3b-4f34-9250-7492ccfd85fe"
 $subscriptionId = "f89ca1d5-8a0f-413e-aa15-8d22bf52c8f6"
 $resourceGroup = "oardevol-hybrid"
+
+# The workload cluster we will deploy
+$workloadClusterName="wld01-cluster"


### PR DESCRIPTION
Updated the scripts to use the /16 network mask that the Hyper-v's `InternalNAT` virtual switch uses.
Interesting commands used while debugging:
- `Get-NetNat` and `Get-NetAdapter` to get the network configuration of the VM
- Connect to the management cluster using `V:\AKS-HCI\WorkingDir\1.0.13.10907> .\kubectl.exe --kubeconfig=.\kubeconfig-mgmt get pods --all-namespaces`
- Shell in the etcd of the management cluster `.\kubectl.exe exec -it --kubeconfig=.\kubeconfig-mgmt -n kube-system etcd-moc-lek74cxc1cu -- /bin/sh` where you can do `apt update && apt install net-tools && ifconfig` to explore the netmask  
- Added the `Get-AksHciCredential` in step 01 to show how you can locally connect to the workload cluster.

